### PR TITLE
feat: Keep GitHub Actions up to date with GitHub's Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,11 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pip" # See documentation for possible values
+  - package-ecosystem: "github-actions" # See documentation for possible values
     directory: "/" # Location of package manifests
+    groups:
+      github-actions:
+        patterns:
+          - "*"  # Group all Actions updates into a single larger pull request
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Keep GitHub Actions up to date with GitHub's Dependabot

* [Keeping your software supply chain secure with Dependabot](https://docs.github.com/en/code-security/dependabot)
* [Keeping your actions up to date with Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot)
* [Configuration options for the `dependabot.yml` file - package-ecosystem](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem)

To see all GitHub Actions dependencies, type:
% `git grep 'uses: ' .github/workflows/`

Example PR : [See](https://github.com/DhavalGojiya/setup-solr-action/pull/25)

Note: The configuration package-ecosystem for pip has been removed, as this project now uses uv, a Python package manager written in Rust. Dependabot support for the pip ecosystem is not needed in this case.