### PR TITLE
feat: Configure Ruff linter pre-commit to perform write operations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,5 +5,6 @@ repos:
   hooks:
     # Run the linter.
     - id: ruff-check
+      args: [ --fix ]
     # Run the formatter.
     - id: ruff-format


### PR DESCRIPTION
## Summary

Allow Ruff linter in pre-commit to automatically fix lint issues by writing files.

After running pre-commit, if any files have lint issues, this will automatically fix them.  

Now we only need to run `git add .` and re-run pre-commit; this time everything will pass,  
instead of running `ruff check --fix .` again.