### PR TITLE
Add Docker support to installation process and update README

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,9 @@
 name: Test CLI
 
 on:
-  pull_request:
-    branches:
-      - main
+  # pull_request:
+  #   branches:
+  #     - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-groups --dev
 
+      - name: Ruff check
+        run: uv run ruff check .
+
       - name: Setup Task
         uses: arduino/setup-task@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,26 +1,33 @@
-# name: Test CLI
+name: Test CLI
 
-# on:
-#   workflow_call:
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
 
-# jobs:
-#   test:
-#     runs-on: ubuntu-latest
-#     steps:
-#       - name: Checkout code
-#         uses: actions/checkout@v4
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
 
-#       - name: Set up Python
-#         uses: actions/setup-python@v4
-#         with:
-#           python-version: "3.13"
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
 
-#       - name: Install uv
-#         uses: astral-sh/setup-uv@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
 
-#       - name: Install dependencies
-#         run: uv sync --all-groups --dev
+      - name: Install dependencies
+        run: uv sync --all-groups --dev
 
-#       - name: Run pytest
-#         working-directory: ./test
-#         run: uv run pytest -s .
+      - name: Setup Task
+        uses: arduino/setup-task@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Test CLI
+        run: task test -- py

--- a/InstallRelease/cli.py
+++ b/InstallRelease/cli.py
@@ -61,7 +61,9 @@ app = typer.Typer(
 def get(
     debug: bool = __optionDebug,
     quiet: bool = __optionQuiet,
-    url: str = typer.Argument(None, help="GitHub/GitLab URL or @mise/<tool-name>"),
+    url: str = typer.Argument(
+        None, help="GitHub/GitLab URL, mise@<tool>, or docker@<image>"
+    ),
     tag_name: str = typer.Option(
         "", "-t", "--tag", help="Select a specific release version."
     ),
@@ -86,6 +88,13 @@ def get(
     setLogger(quiet, debug)
     if url is None or url == "":
         see_help("get")
+
+    # Allow inline version: mise@terraform:v1.12.0 or docker@image:tag
+    for prefix in ("mise@", "docker@"):
+        if url.startswith(prefix) and ":" in url[len(prefix) :] and not tag_name:
+            url, tag_name = url.rsplit(":", 1)
+            break
+
     _get(
         url,
         version=tag_name,

--- a/InstallRelease/cli.py
+++ b/InstallRelease/cli.py
@@ -102,6 +102,7 @@ def get(
         prompt=not approve,
         name=name,
         pkg=pkg,
+        hold=bool(tag_name),
     )
 
 

--- a/InstallRelease/cli_interact.py
+++ b/InstallRelease/cli_interact.py
@@ -111,7 +111,7 @@ def upgrade(
         # ── mise tools ──────────────────────────────────────────────────────
         if i.url.startswith(_mise):
             toolname = i.url[len(_mise) :]
-            pprint(f"Fetching: {toolname}")
+            pprint(f"Fetching: [blue]mise@{toolname}[/blue]")
             versions = MiseInteractProvider(toolname).resolve()
             if versions and (force or versions[0] != state[k].tag_name):
                 with _lock:
@@ -127,7 +127,7 @@ def upgrade(
                 if image_ref.startswith("library/")
                 else image_ref
             )
-            pprint(f"Checking: docker@{cli_image}:{tag}")
+            pprint(f"Checking: [blue]docker@{cli_image}:{tag}[/blue]")
             if docker_needs_update(image_ref, tag, force=force):
                 with _lock:
                     upgrades[i.name] = (i.url, tag, False)

--- a/InstallRelease/cli_interact.py
+++ b/InstallRelease/cli_interact.py
@@ -54,6 +54,7 @@ def get(
     prompt: bool = False,
     name: Optional[str] = None,
     pkg: bool = False,
+    hold: bool = False,
 ) -> None:
     """Resolve URL to provider and install the tool."""
     state_info()
@@ -74,7 +75,12 @@ def get(
         url = "/".join(url.split("/")[:5])
         provider = GitInteractProvider(get_repo_info(url), package_mode=pkg)
     provider.get(
-        version=version, asset_file=asset_file, local=local, prompt=prompt, name=name
+        version=version,
+        asset_file=asset_file,
+        local=local,
+        prompt=prompt,
+        name=name,
+        hold=hold,
     )
 
 

--- a/InstallRelease/cli_interact.py
+++ b/InstallRelease/cli_interact.py
@@ -20,6 +20,10 @@ from InstallRelease.utils import (
 from InstallRelease.providers.base import PROVIDER_STATE_KEY_PREFIXES, InteractProvider
 from InstallRelease.providers.git.main import get_repo_info, GitInteractProvider
 from InstallRelease.providers.mise.main import MiseInteractProvider
+from InstallRelease.providers.docker.main import (
+    DockerInteractProvider,
+    needs_update as docker_needs_update,
+)
 from InstallRelease.config import cache, cache_config, config, dest, pre_release_enabled  # noqa: F401
 
 
@@ -53,9 +57,19 @@ def get(
 ) -> None:
     """Resolve URL to provider and install the tool."""
     state_info()
-    _mise = PROVIDER_STATE_KEY_PREFIXES["mise"]
-    if url.startswith(_mise):
-        provider: InteractProvider = MiseInteractProvider(url[len(_mise) :])
+
+    # User-facing prefixes (typed by the user)
+    # State-key prefixes (used internally by upgrade/pull_state)
+    _mise_user, _mise = "mise@", PROVIDER_STATE_KEY_PREFIXES["mise"]
+    _docker_user, _docker = "docker@", PROVIDER_STATE_KEY_PREFIXES["docker"]
+    if url.startswith(_mise_user):
+        provider: InteractProvider = MiseInteractProvider(url[len(_mise_user) :])
+    elif url.startswith(_mise):
+        provider = MiseInteractProvider(url[len(_mise) :])
+    elif url.startswith(_docker_user):
+        provider = DockerInteractProvider(url[len(_docker_user) :])
+    elif url.startswith(_docker):
+        provider = DockerInteractProvider(url[len(_docker) :])
     else:
         url = "/".join(url.split("/")[:5])
         provider = GitInteractProvider(get_repo_info(url), package_mode=pkg)
@@ -81,6 +95,7 @@ def upgrade(
     pkg_upgrades: set[str] = set()  # names only, for notification
     _lock = threading.Lock()
     _mise = PROVIDER_STATE_KEY_PREFIXES["mise"]
+    _docker = PROVIDER_STATE_KEY_PREFIXES["docker"]
 
     def task(k: str) -> None:
         """Fetch latest version for one tool and bucket it if newer."""
@@ -101,6 +116,21 @@ def upgrade(
             if versions and (force or versions[0] != state[k].tag_name):
                 with _lock:
                     upgrades[i.name] = (i.url, versions[0], False)
+            return
+
+        # ── docker tools ─────────────────────────────────────────────────────
+        if i.url.startswith(_docker):
+            image_ref = i.url[len(_docker) :]
+            tag = state[k].tag_name
+            cli_image = (
+                image_ref[len("library/") :]
+                if image_ref.startswith("library/")
+                else image_ref
+            )
+            pprint(f"Checking: docker@{cli_image}:{tag}")
+            if docker_needs_update(image_ref, tag, force=force):
+                with _lock:
+                    upgrades[i.name] = (i.url, tag, False)
             return
 
         # ── git tools ───────────────────────────────────────────────────────

--- a/InstallRelease/providers/base.py
+++ b/InstallRelease/providers/base.py
@@ -9,6 +9,7 @@ PROVIDER_STATE_KEY_PREFIXES: dict[str, str] = {
     "github": "https://github.com",
     "gitlab": "https://gitlab.com",
     "mise": "mise:",
+    "docker": "docker:",
 }
 
 

--- a/InstallRelease/providers/base.py
+++ b/InstallRelease/providers/base.py
@@ -65,5 +65,6 @@ class InteractProvider(ABC):
         local: bool = True,
         prompt: bool = False,
         name: Optional[str] = None,
+        hold: bool = False,
         **kwargs: Any,
     ) -> None: ...

--- a/InstallRelease/providers/docker/__init__.py
+++ b/InstallRelease/providers/docker/__init__.py
@@ -1,0 +1,3 @@
+from InstallRelease.providers.docker.main import (
+    DockerInteractProvider as DockerInteractProvider,
+)

--- a/InstallRelease/providers/docker/config.py
+++ b/InstallRelease/providers/docker/config.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+# Shell wrapper written to dest/<toolname>.
+# {ref}  — image CLI ref (e.g. alpine:latest)
+# {args} — "$@" when image has ENTRYPOINT; "toolname "$@"" when it does not
+# ${{PWD}} becomes ${PWD} after .format() — intentional shell variable reference.
+WRAPPER_TEMPLATE = """\
+#!/bin/sh
+termflag=$([ -t 0 ] && echo -n "-t")
+docker run --rm -i $termflag -v "${{PWD}}:/tmp/cmd" -w /tmp/cmd {ref} {args}
+"""

--- a/InstallRelease/providers/docker/main.py
+++ b/InstallRelease/providers/docker/main.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import requests
+
+from InstallRelease.config import dest
+from InstallRelease.helper import save_state
+from InstallRelease.providers.base import PROVIDER_STATE_KEY_PREFIXES, InteractProvider
+from InstallRelease.providers.docker.config import WRAPPER_TEMPLATE
+from InstallRelease.providers.docker.schemas import DockerImage
+from InstallRelease.providers.git.schemas import Release
+from InstallRelease.utils import logger, mkdir, pprint, show_table
+
+_DOCKERHUB_AUTH = "https://auth.docker.io/token"
+_DOCKERHUB_REGISTRY = "https://registry-1.docker.io/v2"
+# Accept both single-arch and multi-arch manifests
+_MANIFEST_ACCEPT = (
+    "application/vnd.oci.image.index.v1+json,"
+    "application/vnd.docker.distribution.manifest.list.v2+json,"
+    "application/vnd.docker.distribution.manifest.v2+json"
+)
+
+
+def _is_dockerhub(image: str) -> bool:
+    """Return True if the image is hosted on Docker Hub (no domain in first component)."""
+    first = image.split("/")[0]
+    return "." not in first and ":" not in first
+
+
+def _get_local_digest(cli_ref: str) -> str:
+    """Return the sha256 RepoDigest for a locally cached image, or empty string."""
+    result = subprocess.run(
+        ["docker", "inspect", "--format", "{{index .RepoDigests 0}}", cli_ref],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    raw = result.stdout.strip()
+    # RepoDigest format: "image@sha256:abc123..." — extract the digest part
+    # Returns "<no value>" when the image has no RepoDigest (e.g. locally built)
+    if not raw or raw == "<no value>" or "@" not in raw:
+        return ""
+    return raw.split("@")[-1]
+
+
+def _get_remote_digest(image: str, tag: str) -> str:
+    """Return the manifest digest from Docker Hub, or empty string on failure/non-Hub image."""
+    if not _is_dockerhub(image):
+        return ""
+    try:
+        token_resp = requests.get(
+            _DOCKERHUB_AUTH,
+            params={
+                "service": "registry.docker.io",
+                "scope": f"repository:{image}:pull",
+            },
+            timeout=10,
+        )
+        token_resp.raise_for_status()
+        token = token_resp.json()["token"]
+
+        manifest_resp = requests.head(
+            f"{_DOCKERHUB_REGISTRY}/{image}/manifests/{tag}",
+            headers={"Authorization": f"Bearer {token}", "Accept": _MANIFEST_ACCEPT},
+            timeout=10,
+        )
+        return manifest_resp.headers.get("Docker-Content-Digest", "")
+    except Exception as e:
+        logger.debug(f"Remote digest check failed for {image}:{tag}: {e}")
+        return ""
+
+
+def needs_update(image: str, tag: str, force: bool = False) -> bool:
+    """Return True if the Docker image should be re-pulled.
+
+    Pinned (non-latest) tags never auto-upgrade unless --force.
+    For latest: compares local RepoDigest against the remote manifest digest.
+    """
+    if force:
+        return True
+    if tag != "latest":
+        return False
+    local = _get_local_digest(DockerImage(image=image, tag=tag).cli_ref)
+    remote = _get_remote_digest(image, tag)
+    return not remote or local != remote  # no remote info → conservatively pull
+
+
+def _get_entrypoint(cli_ref: str) -> list[str]:
+    """Return the ENTRYPOINT of a pulled image, or empty list if none is set."""
+    result = subprocess.run(
+        ["docker", "inspect", "--format", "{{json .Config.Entrypoint}}", cli_ref],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    raw = result.stdout.strip()
+    if not raw or raw == "null":
+        return []
+    try:
+        return json.loads(raw) or []
+    except json.JSONDecodeError:
+        return []
+
+
+def _split_image_tag(ref: str) -> tuple[str, str]:
+    """Split an image reference into (image, tag); default tag is 'latest'."""
+    colon = ref.rfind(":")
+    if colon > -1:
+        return ref[:colon], ref[colon + 1 :]
+    return ref, "latest"
+
+
+class DockerInteractProvider(InteractProvider):
+    """InteractProvider that wraps a Docker image as a local CLI tool.
+
+    Writes a shell script to dest/<toolname> that proxies all invocations
+    through `docker run`, mounting the current directory into the container.
+
+    Steps
+    -----
+    1. resolve    → return the target tag(s) (given version or image default)
+    2. select     → build a DockerImage for the chosen tag
+    3. prompt     → show image details and confirm
+    4. install    → docker pull + write executable wrapper script
+    5. save_state → persist to cache as a Release
+    """
+
+    def __init__(self, image_ref: str) -> None:
+        """Accept image_ref without the docker:// prefix, e.g. 'hashicorp/terraform:1.7.0'."""
+        image, tag = _split_image_tag(image_ref)
+        if "/" not in image:
+            image = f"library/{image}"
+        self._image = DockerImage(image=image, tag=tag)
+
+    # ── Step 1 ───────────────────────────────────────────────────────────
+
+    def resolve(self, version: str = "", pre_release: bool = False) -> list[str]:
+        """Return the tag to install: given version or the image's default tag."""
+        return [version] if version else [self._image.tag]
+
+    # ── Step 2 ───────────────────────────────────────────────────────────
+
+    def select(self, candidates: list[str], **hints: Any) -> Optional[DockerImage]:
+        """Build a DockerImage for the first candidate tag."""
+        if not candidates:
+            return None
+        return DockerImage(image=self._image.image, tag=candidates[0])
+
+    # ── Step 3 ───────────────────────────────────────────────────────────
+
+    def prompt(self, toolname: str, candidate: DockerImage) -> str:
+        """Display image info and ask for install confirmation."""
+        show_table(
+            data=[{"Tool": toolname, "Image": candidate.image, "Tag": candidate.tag}],
+            title=f"Install {toolname} (via Docker)",
+        )
+        pprint("[color(34)]Install this tool (Y/n): ", end="")
+        return input().strip().lower() or "y"
+
+    # ── Step 4 ───────────────────────────────────────────────────────────
+
+    def install(
+        self, candidate: DockerImage, toolname: str, temp_dir: str, local: bool
+    ) -> bool:
+        """Pull the Docker image and write an executable wrapper script to dest."""
+        pprint(f"[cyan]Pulling {candidate.cli_ref}...[/cyan]")
+        result = subprocess.run(["docker", "pull", candidate.cli_ref], check=False)
+        if result.returncode != 0:
+            logger.error(f"docker pull failed for {candidate.cli_ref}")
+            return False
+
+        mkdir(dest)
+        script_path = os.path.join(dest, toolname)
+        entrypoint = _get_entrypoint(candidate.cli_ref)
+        # Images without ENTRYPOINT need the command name prepended explicitly
+        args = '"$@"' if entrypoint else f'{toolname} "$@"'
+        with open(script_path, "w") as f:
+            f.write(WRAPPER_TEMPLATE.format(ref=candidate.cli_ref, args=args))
+        os.chmod(script_path, 0o755)
+        logger.info(f"Installed wrapper: {script_path}")
+        return True
+
+    # ── Step 5 ───────────────────────────────────────────────────────────
+
+    def save_state(self, key: str, result: Release) -> None:
+        save_state(key, result)
+
+    # ── Template method ──────────────────────────────────────────────────
+
+    def get(
+        self,
+        version: str = "",
+        local: bool = True,
+        prompt: bool = False,
+        name: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Orchestrate the full install flow: resolve -> select -> prompt -> install -> save."""
+        toolname = name or self._image.name
+
+        # Step 1
+        candidates = self.resolve(version=version)
+
+        # Step 2
+        image = self.select(candidates)
+        if image is None:
+            return
+
+        # Step 3
+        if prompt:
+            decision = self.prompt(toolname, image)
+            if decision != "y":
+                return
+            pprint("\n[magenta]Pulling image...[/magenta]")
+
+        # Step 4
+        if not self.install(image, toolname=toolname, temp_dir="", local=local):
+            return
+
+        # Step 5
+        now_str = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        release = Release(
+            url=f"docker@{image.cli_image}",  # user-facing format shown by ir ls
+            name=toolname,
+            tag_name=image.tag,
+            prerelease=False,
+            published_at=now_str,
+            assets=[],
+            description=f"Docker image wrapper: {image.cli_ref}",
+        )
+        # Pin hold_update for any non-latest tag so upgrade skips them
+        release.hold_update = image.tag != "latest"
+
+        state_key = f"{PROVIDER_STATE_KEY_PREFIXES['docker']}{image.image}#{toolname}"
+        self.save_state(state_key, release)

--- a/InstallRelease/providers/docker/schemas.py
+++ b/InstallRelease/providers/docker/schemas.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class DockerImage:
+    """Parsed Docker image reference with repository path and tag."""
+
+    image: str  # e.g. "hashicorp/terraform" or "library/alpine"
+    tag: str  # e.g. "latest" or "1.7.0"
+
+    @property
+    def cli_image(self) -> str:
+        """Image name without library/ prefix, suitable for docker CLI and display."""
+        return (
+            self.image[len("library/") :]
+            if self.image.startswith("library/")
+            else self.image
+        )
+
+    @property
+    def cli_ref(self) -> str:
+        """Full reference for docker CLI: cli_image:tag."""
+        return f"{self.cli_image}:{self.tag}"
+
+    @property
+    def name(self) -> str:
+        return self.image.split("/")[-1]

--- a/InstallRelease/providers/git/main.py
+++ b/InstallRelease/providers/git/main.py
@@ -328,6 +328,7 @@ class GitInteractProvider(InteractProvider):
         local: bool = True,
         prompt: bool = False,
         name: Optional[str] = None,
+        hold: bool = False,
         **kwargs: Any,
     ) -> None:
         """Orchestrate the full install flow: resolve -> select -> prompt -> install -> save."""
@@ -407,7 +408,7 @@ class GitInteractProvider(InteractProvider):
         release = self._selected_release
         if release is None:
             return
-        release.hold_update = bool(version)  # pin version if explicitly requested
+        release.hold_update = hold
 
         resolved_words, _ = _resolve_release_words(
             custom_release_words, cached_custom_words

--- a/InstallRelease/providers/git/main.py
+++ b/InstallRelease/providers/git/main.py
@@ -243,7 +243,7 @@ class GitInteractProvider(InteractProvider):
             repo_name = self.repo.repo_url.rstrip("/").rsplit("/", 1)[-1]
             pprint(
                 f"[bold cyan]\nYou can retry installing via [mise] provider: "
-                f"\n[green]ir get @mise/{repo_name}[/green][/]\n"
+                f"\n[green]ir get mise@{repo_name}[/green][/]\n"
             )
             return None
         return cast(ReleaseAssets, result)

--- a/InstallRelease/providers/mise/main.py
+++ b/InstallRelease/providers/mise/main.py
@@ -166,6 +166,7 @@ class MiseInteractProvider(InteractProvider):
         local: bool = True,
         prompt: bool = False,
         name: Optional[str] = None,
+        hold: bool = False,
         **kwargs: Any,
     ) -> None:
         toolname = name or self.toolname
@@ -215,7 +216,7 @@ class MiseInteractProvider(InteractProvider):
             assets=[release_asset],
             description=asset.description or "Installed via mise/aqua registry",
         )
-        release.hold_update = bool(version)
+        release.hold_update = hold
 
         state_key = f"{PROVIDER_STATE_KEY_PREFIXES['mise']}{self.toolname}#{toolname}"
         self.save_state(state_key, release)

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This can be any tool you want to install, which is pre-compiled for your device 
   - [Install tool from GitHub/GitLab releases 🌈](#install-tool-from-githubgitlab-releases-)
     - [Install as system package (deb/rpm/appimage) 📦](#install-as-system-package-debrpmappimage-)
   - [Install tool via mise registry 🧩](#install-tool-via-mise-registry-)
+  - [Install Docker image as a CLI tool 🐳](#install-docker-image-as-a-cli-tool-)
   - [Install specific release asset from GitHub/GitLab releases 🔦](#install-specific-release-asset-from-githubgitlab-releases-)
     - [Method 1: Interactive Selection (Recommended)](#method-1-interactive-selection-recommended)
     - [Method 2: Command-line Flag](#method-2-command-line-flag)
@@ -117,8 +118,16 @@ If you want to change the installation path, you can use the `ir config --path <
 Example: Installing [deno (Rust-based JavaScript runtime)](https://github.com/denoland/deno) directly from its GitHub releases:
 
 ```bash
-# Usage: ir get [GITHUB-URL or GITLAB-URL or @mise/TOOL-NAME]
+# Usage: ir get [GITHUB-URL or GITLAB-URL or mise@<TOOL> or docker@<IMAGE-URI>]
+
+# GitHub URL
 ❯ ir get https://github.com/denoland/deno
+
+# mise registry
+❯ ir get mise@terraform
+
+# Docker image with latest tag
+❯ ir get docker@hashicorp/terraform:latest
 ```
 
 Verify the installation:
@@ -239,11 +248,15 @@ This is useful for tools that provide `.deb`, `.rpm` or `appimage` releases that
 
 #### Install tool via mise registry 🧩
 
-Some tools (like Terraform, Packer, etc.) don't publish platform-specific binaries on GitHub releases — they host their own download URLs instead. For these tools, `ir` can resolve the correct download URL via the [mise](https://mise.jdx.dev/) / [aqua](https://aquaproj.github.io/) registry using the `@mise/` prefix.
+Some tools (like Terraform, Packer, etc.) don't publish platform-specific binaries on GitHub releases — they host their own download URLs instead. For these tools, `ir` can resolve the correct download URL via the [mise](https://mise.jdx.dev/) / [aqua](https://aquaproj.github.io/) registry using the `mise@` prefix.
 
 ```bash
-# Usage: ir get @mise/<tool-name>
-❯ ir get @mise/terraform
+# Usage: ir get mise@<tool-name>
+❯ ir get mise@terraform
+
+# Install a specific version (inline or via --tag)
+❯ ir get mise@terraform:v1.12.0
+❯ ir get mise@terraform -t v1.12.0
 ```
 
 ```
@@ -256,9 +269,39 @@ Some tools (like Terraform, Packer, etc.) don't publish platform-specific binari
 Install this tool (Y/n): y
 ```
 
-Tools installed via `@mise/` are also tracked by `ir ls` and upgraded with `ir upgrade` just like GitHub/GitLab tools.
+Tools installed via `mise@` are also tracked by `ir ls` and upgraded with `ir upgrade` just like GitHub/GitLab tools.
 
 > **Note:** The mise provider currently only supports tools with **HTTP-based** download URLs in the aqua registry. Tools that use `github_release` type assets should be installed directly via their GitHub URL (`ir get <github-url>`) instead.
+
+#### Install Docker image as a CLI tool 🐳
+
+`ir` can wrap any Docker image as a local CLI tool using the `docker@` prefix. It pulls the image, detects its entrypoint, and writes an executable wrapper script to `~/bin/<toolname>` that proxies all invocations through `docker run`.
+
+```bash
+# Usage: ir get docker@<image>[:<tag>]
+❯ ir get docker@hashicorp/terraform
+
+# Install a specific tag (inline or via --tag)
+❯ ir get docker@hashicorp/terraform:1.7.0
+❯ ir get docker@hashicorp/terraform -t 1.7.0
+
+# Custom tool name
+❯ ir get docker@mcr.microsoft.com/azure-cli -n az
+```
+
+```
+         Install terraform (via Docker)
+┏━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┓
+┃ Tool      ┃ Image                 ┃ Tag    ┃
+┡━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━┩
+│ terraform │ hashicorp/terraform   │ latest │
+└───────────┴───────────────────────┴────────┘
+Install this tool (Y/n): y
+```
+
+- **Latest tags** (`latest`) are checked for updates via digest comparison during `ir upgrade` — only re-pulled when the remote image has changed.
+- **Pinned tags** (e.g. `1.7.0`) are held from auto-upgrade; use `ir upgrade --force` to re-pull.
+- The wrapper mounts the current directory into the container at `/tmp/cmd`, so the tool sees your local files.
 
 ### Install specific release asset from GitHub/GitLab releases 🔦
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ Changelog = "https://github.com/Rishang/install-release/release"
 dev = [
   "mypy>=1.17.1",
   "nuitka>=2.7.13",
+  "pytest>=8.4.2",
   "pre-commit>=4.3.0",
   "ruff>=0.12.12",
   "setuptools",

--- a/test/asset.yml
+++ b/test/asset.yml
@@ -24,13 +24,13 @@ repos:
     grep: "version.BuildInfo"
 
 - name: kubectl
-  cmd: ir get @mise/kubectl -n kubectl -y
+  cmd: ir get mise@kubectl -n kubectl -y
   validate:
     cmd: kubectl version --client
     grep: 'Client Version:'
 
-- name: terraform
-  cmd: ir get docker@hashicorp/terraform -y
-  validate:
-    cmd: terraform version
-    grep: "Terraform"
+# - name: terraform
+#   cmd: ir get docker@hashicorp/terraform -y
+#   validate:
+#     cmd: terraform version
+#     grep: "Terraform"

--- a/test/asset.yml
+++ b/test/asset.yml
@@ -17,14 +17,20 @@ repos:
     cmd: ttyd --help
     grep: ttyd
 
-- name: terraform
-  cmd: ir get @mise/terraform -n terraform -y
+- name: helm
+  cmd: ir get mise@helm -y
   validate:
-    cmd: terraform --version
-    grep: Terraform
+    cmd: helm version
+    grep: "version.BuildInfo"
 
 - name: kubectl
   cmd: ir get @mise/kubectl -n kubectl -y
   validate:
     cmd: kubectl version --client
     grep: 'Client Version:'
+
+- name: terraform
+  cmd: ir get docker@hashicorp/terraform -y
+  validate:
+    cmd: terraform version
+    grep: "Terraform"

--- a/test/images/fedora/Dockerfile
+++ b/test/images/fedora/Dockerfile
@@ -12,6 +12,8 @@ RUN dnf install -y \
 # Install uv (binary from official image)
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
+ENV UV_LINK_MODE=copy
+
 WORKDIR /app
 
 # Copy dependency manifests first for better layer caching (paths relative to context = repo root)

--- a/test/images/fedora/Dockerfile
+++ b/test/images/fedora/Dockerfile
@@ -17,8 +17,8 @@ WORKDIR /app
 # Copy dependency manifests first for better layer caching (paths relative to context = repo root)
 COPY pyproject.toml uv.lock ./
 
-# Sync dependencies and install the package (CLI: ir, install-release)
-RUN uv sync --frozen
+# Sync dependencies (including dev tools like pytest) and install package
+RUN uv sync --frozen --dev
 
 # Ensure venv bin is on PATH so `ir` and `install-release` are available
 ENV PATH="/root/bin:/app/.venv/bin:$PATH"

--- a/test/images/ubuntu/Dockerfile
+++ b/test/images/ubuntu/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:25.10
 
-RUN apt-get update && apt-get install -y \
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
     curl \
     sudo \
     libmagic1 \

--- a/test/images/ubuntu/Dockerfile
+++ b/test/images/ubuntu/Dockerfile
@@ -1,12 +1,9 @@
-FROM ubuntu:25.10
+FROM python:3.13-slim
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y \
     curl \
     sudo \
-    libmagic1 \
-    python3 \
-    python3-venv \
-    && rm -rf /var/lib/apt/lists/*
+    libmagic1
 
 # Install uv (binary from official image)
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/

--- a/test/images/ubuntu/Dockerfile
+++ b/test/images/ubuntu/Dockerfile
@@ -16,8 +16,8 @@ WORKDIR /app
 # Copy dependency manifests first for better layer caching (paths relative to context = repo root)
 COPY pyproject.toml uv.lock ./
 
-# Sync dependencies and install the package (CLI: ir, install-release)
-RUN uv sync --frozen
+# Sync dependencies (including dev tools like pytest) and install package
+RUN uv sync --frozen --dev
 
 # Ensure venv bin is on PATH so `ir` and `install-release` are available
 ENV PATH="/root/bin:/app/.venv/bin:$PATH"

--- a/test/images/ubuntu/Dockerfile
+++ b/test/images/ubuntu/Dockerfile
@@ -8,6 +8,8 @@ RUN apt-get update && apt-get install -y \
 # Install uv (binary from official image)
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
+ENV UV_LINK_MODE=copy
+
 WORKDIR /app
 
 # Copy dependency manifests first for better layer caching (paths relative to context = repo root)

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -2,6 +2,14 @@
 # set -x
 cd "$(dirname "$0")/.."
 
+function ensure_host_config_file {
+  local host_config="$HOME/.config/install_release/config.json"
+  mkdir -p "$(dirname "$host_config")"
+  if [ ! -f "$host_config" ]; then
+    echo '{}' >"$host_config"
+  fi
+}
+
 function build_ubuntu {
   docker build -t install-release-ubuntu:latest -f test/images/ubuntu/Dockerfile .
 }
@@ -12,6 +20,7 @@ function build_fedora {
 
 case $1 in
   "ubuntu")
+    ensure_host_config_file
     docker rm -f ir-ubuntu
     docker images | grep install-release-ubuntu || build_ubuntu
     docker run -d \
@@ -28,6 +37,7 @@ case $1 in
     # docker exec -it ir-ubuntu bash
     ;;
   "fedora")
+    ensure_host_config_file
     docker rm -f ir-fedora
     docker images | grep install-release-fedora || build_fedora
     docker run -d \

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -24,7 +24,7 @@ case $1 in
       -v u-ir:/app/.venv \
       -e HOME=/root \
       install-release-ubuntu:latest
-    docker exec ir-ubuntu bash -c '/usr/local/bin/uv sync'
+    docker exec ir-ubuntu bash -c '/usr/local/bin/uv sync --dev'
     # docker exec -it ir-ubuntu bash
     ;;
   "fedora")
@@ -40,7 +40,7 @@ case $1 in
       -v f-ir:/app/.venv \
       -e HOME=/root \
       install-release-fedora:latest
-    docker exec ir-fedora bash -c '/usr/local/bin/uv sync'
+    docker exec ir-fedora bash -c '/usr/local/bin/uv sync --dev'
     docker exec -it ir-fedora bash
 
     ;;

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -6,7 +6,7 @@ function ensure_host_config_file {
   local host_config="$HOME/.config/install_release/config.json"
   mkdir -p "$(dirname "$host_config")"
   if [ ! -f "$host_config" ]; then
-    echo '{}' >"$host_config"
+    echo '{"config": {}}' >"$host_config"
   fi
 }
 

--- a/test/test_install.py
+++ b/test/test_install.py
@@ -46,15 +46,15 @@ def test_get(repo):
     """Install a tool and validate it runs correctly."""
     # Install
     stdout, stderr, rc = docker_exec(CONTAINER, repo["cmd"])
-    print(stdout)
+    assert rc == 0, (
+        f"Install failed for {repo['name']}: stdout={stdout}, stderr={stderr}"
+    )
 
     # Validate
-    validate_cmd = (
-        f"{repo['validate']['cmd']} 2>&1 | grep -i '{repo['validate']['grep']}'"
-    )
-    stdout, stderr, rc = docker_exec(CONTAINER, validate_cmd)
-
-    assert rc == 0, (
+    stdout, stderr, rc = docker_exec(CONTAINER, repo["validate"]["cmd"])
+    output = f"{stdout}\n{stderr}".lower()
+    expected = repo["validate"]["grep"].lower()
+    assert rc == 0 and expected in output, (
         f"Validation failed for {repo['name']}: stdout={stdout}, stderr={stderr}"
     )
     print(f"Validation passed for {repo['name']}")

--- a/uv.lock
+++ b/uv.lock
@@ -165,12 +165,24 @@ wheels = [
 ]
 
 [[package]]
-name = "filelock"
-version = "3.25.2"
+name = "exceptiongroup"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694", size = 40480, upload-time = "2026-03-11T20:45:38.487Z" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70", size = 26759, upload-time = "2026-03-11T20:45:37.437Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.28.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/17/6e8890271880903e3538660a21d63a6c1fea969ac71d0d6b608b78727fa9/filelock-3.28.0.tar.gz", hash = "sha256:4ed1010aae813c4ee8d9c660e4792475ee60c4a0ba76073ceaf862bd317e3ca6", size = 56474, upload-time = "2026-04-14T22:54:33.625Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/21/2f728888c45033d34a417bfcd248ea2564c9e08ab1bfd301377cf05d5586/filelock-3.28.0-py3-none-any.whl", hash = "sha256:de9af6712788e7171df1b28b15eba2446c69721433fa427a9bee07b17820a9db", size = 39189, upload-time = "2026-04-14T22:54:32.037Z" },
 ]
 
 [[package]]
@@ -192,6 +204,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "install-release"
 version = "0.7.2"
 source = { editable = "." }
@@ -209,6 +230,7 @@ dev = [
     { name = "mypy" },
     { name = "nuitka" },
     { name = "pre-commit" },
+    { name = "pytest" },
     { name = "ruff" },
     { name = "setuptools" },
     { name = "types-requests" },
@@ -229,6 +251,7 @@ dev = [
     { name = "mypy", specifier = ">=1.17.1" },
     { name = "nuitka", specifier = ">=2.7.13" },
     { name = "pre-commit", specifier = ">=4.3.0" },
+    { name = "pytest", specifier = ">=8.4.2" },
     { name = "ruff", specifier = ">=0.12.12" },
     { name = "setuptools" },
     { name = "types-requests", specifier = ">=2.32.4.20250809" },
@@ -423,6 +446,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1c/48/e54130d57b89fc015d702e98a1a217b5757625d01a01cc07d29fd046d336/nuitka-4.0.8.tar.gz", hash = "sha256:3f87e87e4d3773997944ce401145ef21461337121d39ea0fbe678274005e60ba", size = 4422692, upload-time = "2026-04-10T07:18:15.109Z" }
 
 [[package]]
+name = "packaging"
+version = "26.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+]
+
+[[package]]
 name = "pathspec"
 version = "1.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -438,6 +470,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -463,6 +504,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -723,7 +782,7 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "21.2.3"
+version = "21.2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -732,9 +791,9 @@ dependencies = [
     { name = "python-discovery" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/8c/bdd9f89f89e4a787ac61bb2da4d884bc45e0c287ec694dfa3170dddd5cfe/virtualenv-21.2.3.tar.gz", hash = "sha256:9bb6d1414ab55ca624371e30c7719c32f183ef44da544ef8aa44a456de7ac191", size = 5844776, upload-time = "2026-04-14T01:10:36.692Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/98/3a7e644e19cb26133488caff231be390579860bbbb3da35913c49a1d0a46/virtualenv-21.2.4.tar.gz", hash = "sha256:b294ef68192638004d72524ce7ef303e9d0cf5a44c95ce2e54a7500a6381cada", size = 5850742, upload-time = "2026-04-14T22:15:31.438Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/19/bc7c4e05f42532863cf2ae7e7e847beab25835934e0410160b47eeff1e35/virtualenv-21.2.3-py3-none-any.whl", hash = "sha256:486652347ea8526d91e9807c0274583cb7ba31dd4942ff10fb5621402f0fe0d8", size = 5828329, upload-time = "2026-04-14T01:10:34.809Z" },
+    { url = "https://files.pythonhosted.org/packages/27/8d/edd0bd910ff803c308ee9a6b7778621af0d10252219ad9f19ef4d4982a61/virtualenv-21.2.4-py3-none-any.whl", hash = "sha256:29d21e941795206138d0f22f4e45ff7050e5da6c6472299fb7103318763861ac", size = 5831232, upload-time = "2026-04-14T22:15:29.342Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Fix unexpected set to hold stage for upgraded packages
- Introduced Docker image handling in the installation logic, allowing users to install CLI tools via Docker using the `docker@` prefix.
- Updated the `get` function to recognize Docker image references and manage installation accordingly.
- Enhanced the README to include instructions for installing tools as Docker images, with examples for usage and version specification.
- Refactored the GitHub Actions workflow to use updated action versions for improved reliability.