### PR TITLE
Add support for install github release via mise provider

### DIFF
--- a/InstallRelease/helper/install.py
+++ b/InstallRelease/helper/install.py
@@ -111,6 +111,12 @@ def install_bin(
 
         bin_files.append(file)
 
+    # If multiple binaries are found, use the name to disambiguate
+    if len(bin_files) > 1 and name:
+        named = [f for f in bin_files if os.path.basename(f) == name]
+        if len(named) == 1:
+            bin_files = named
+
     if len(bin_files) != 1:
         logger.error(f"Expected a single binary, found: {bin_files}")
         return False

--- a/InstallRelease/providers/mise/main.py
+++ b/InstallRelease/providers/mise/main.py
@@ -12,7 +12,11 @@ from InstallRelease.config import config, dest
 from InstallRelease.helper import extract_url, install_bin, save_state
 from InstallRelease.providers.base import PROVIDER_STATE_KEY_PREFIXES, InteractProvider
 from InstallRelease.providers.git.schemas import Release, ReleaseAssets
-from InstallRelease.providers.mise.registry import get_backend, resolve_download_url
+from InstallRelease.providers.mise.registry import (
+    get_aqua_registry_yaml,
+    get_backend,
+    resolve_download_url,
+)
 from InstallRelease.providers.mise.schemas import AquaAsset, MiseToolInfo
 from InstallRelease.utils import logger, mkdir, pprint, show_table
 
@@ -20,23 +24,38 @@ _GITHUB_API = "https://api.github.com"
 
 
 def _get_github_versions(
-    owner: str, repo: str, token: str = "", pre_release: bool = False
+    owner: str,
+    repo: str,
+    token: str = "",
+    *,
+    use_tags: bool = False,
+    pre_release: bool = False,
 ) -> list[str]:
-    """Return stable release tag names from GitHub (newest first), excluding drafts."""
+    """Return version tags from GitHub (newest first).
+
+    Uses the tags API when ``use_tags`` is True, otherwise the releases API
+    (which filters out drafts and optionally pre-releases).
+    """
     headers = {"Accept": "application/vnd.github+json"}
     if token:
         headers["Authorization"] = f"token {token}"
-    url = f"{_GITHUB_API}/repos/{owner}/{repo}/releases"
+    endpoint = "tags" if use_tags else "releases"
     try:
-        resp = requests.get(url, headers=headers, timeout=10)
+        resp = requests.get(
+            f"{_GITHUB_API}/repos/{owner}/{repo}/{endpoint}",
+            headers=headers,
+            timeout=10,
+        )
         resp.raise_for_status()
+        if use_tags:
+            return [t["name"] for t in resp.json()]
         return [
             r["tag_name"]
             for r in resp.json()
             if not r.get("draft") and (pre_release or not r.get("prerelease"))
         ]
     except Exception as e:
-        logger.debug(f"Failed to fetch GitHub releases for {owner}/{repo}: {e}")
+        logger.debug(f"Failed to fetch GitHub {endpoint} for {owner}/{repo}: {e}")
         return []
 
 
@@ -57,11 +76,24 @@ class MiseInteractProvider(InteractProvider):
         self._asset: AquaAsset | None = None
         self._version: str = ""
         self._backend: MiseToolInfo | None = None
+        self._registry: dict = {}
 
     def _ensure_backend(self) -> bool:
+        if self._backend is not None:
+            return True
+        self._backend = get_backend(self.toolname)
         if self._backend is None:
-            self._backend = get_backend(self.toolname)
-        return self._backend is not None
+            return False
+        try:
+            self._registry = get_aqua_registry_yaml(self._backend.aqua_path)
+            pkgs = self._registry.get("packages", [])
+            if pkgs:
+                self._backend.version_source = pkgs[0].get(
+                    "version_source", "github_release"
+                )
+        except Exception:
+            pass
+        return True
 
     # ── Step 1 ───────────────────────────────────────────────────────────
 
@@ -81,9 +113,12 @@ class MiseInteractProvider(InteractProvider):
 
         owner, repo = self._backend.owner, self._backend.repo  # type: ignore[union-attr]
         token = getattr(config, "token", "")
-        versions = _get_github_versions(owner, repo, token, pre_release=pre_release)
+        use_tags = self._backend.version_source == "github_tag"  # type: ignore[union-attr]
+        versions = _get_github_versions(
+            owner, repo, token, use_tags=use_tags, pre_release=pre_release
+        )
         if not versions:
-            logger.warning(f"No releases found for {owner}/{repo}")
+            logger.warning(f"No versions found for {owner}/{repo}")
         return versions
 
     # ── Step 2 ───────────────────────────────────────────────────────────
@@ -94,7 +129,7 @@ class MiseInteractProvider(InteractProvider):
             return None
 
         version = candidates[0]
-        asset = resolve_download_url(self.toolname, version)
+        asset = resolve_download_url(self.toolname, version, registry=self._registry)
         if asset is None:
             logger.error(
                 f"Could not resolve download URL for '{self.toolname}' {version}"

--- a/InstallRelease/providers/mise/registry.py
+++ b/InstallRelease/providers/mise/registry.py
@@ -12,7 +12,7 @@ from InstallRelease.providers.mise.config import (
     _trim_v,
 )
 from InstallRelease.providers.mise.schemas import AquaAsset, MiseToolInfo
-from InstallRelease.utils import logger, pprint
+from InstallRelease.utils import logger
 
 
 def _expand_template(
@@ -57,16 +57,18 @@ def get_backend(toolname: str) -> MiseToolInfo | None:
     description = data.get("description", "")
 
     for backend in data.get("backends", []):
-        if backend.startswith("aqua:"):
-            path = backend[len("aqua:") :]
-            parts = path.split("/")
-            if len(parts) >= 2:
-                return MiseToolInfo(
-                    owner=parts[0],
-                    repo=parts[1],
-                    aqua_path=path,
-                    description=description,
-                )
+        backend_str = backend.get("full", "") if isinstance(backend, dict) else backend
+        if not backend_str.startswith("aqua:"):
+            continue
+        path = backend_str.removeprefix("aqua:")
+        parts = path.split("/")
+        if len(parts) >= 2:
+            return MiseToolInfo(
+                owner=parts[0],
+                repo=parts[1],
+                aqua_path=path,
+                description=description,
+            )
     return None
 
 
@@ -87,14 +89,16 @@ def resolve_download_url(
     *,
     os_name: str | None = None,
     arch: str | None = None,
+    registry: dict | None = None,
 ) -> AquaAsset | None:
     """Resolve the download URL for *toolname* at *version* via the aqua registry.
 
     Args:
-        toolname: Tool name as it appears in the mise registry (e.g. ``"fzf"``).
-        version:  Version tag (e.g. ``"v0.55.0"``).
-        os_name:  Override detected OS (useful for tests / cross-resolution).
-        arch:     Override detected architecture.
+        toolname:  Tool name as it appears in the mise registry (e.g. ``"fzf"``).
+        version:   Version tag (e.g. ``"v0.55.0"``).
+        os_name:   Override detected OS (useful for tests / cross-resolution).
+        arch:      Override detected architecture.
+        registry:  Pre-fetched aqua registry dict; fetched if not provided.
 
     Returns:
         An ``AquaAsset`` with the expanded download URL, or ``None`` on failure.
@@ -106,10 +110,11 @@ def resolve_download_url(
     owner, repo = backend.owner, backend.repo
     description = backend.description
 
-    try:
-        registry = get_aqua_registry_yaml(backend.aqua_path)
-    except Exception:
-        return None
+    if registry is None:
+        try:
+            registry = get_aqua_registry_yaml(backend.aqua_path)
+        except Exception:
+            return None
 
     packages = registry.get("packages", [])
     if not packages:
@@ -120,13 +125,7 @@ def resolve_download_url(
     arch = arch or _current_arch()
     pkg_type = pkg.get("type", "github_release")
 
-    if pkg_type == "github_release":
-        pprint(
-            f"\n[bold cyan]💡 [yellow]{toolname}[/yellow] uses GitHub releases. "
-            f"Install directly with: [green]ir get https://github.com/{owner}/{repo}[/green][/bold cyan]\n"
-        )
-        return None
-    elif pkg_type != "http":
+    if pkg_type not in ("github_release", "http"):
         logger.info(
             f"Skipping unsupported aqua package type '{pkg_type}' for {toolname}"
         )
@@ -135,8 +134,6 @@ def resolve_download_url(
     override = _pick_latest_override(pkg)
 
     # ── type: http ─────────────────────────────────────────────────────────
-    # The package declares a full URL template rather than a GitHub asset name.
-    # The override may narrow the URL, but if absent the pkg-level url is used.
     if pkg_type == "http":
         url_template = pkg.get("url", "")
         if override:
@@ -148,7 +145,15 @@ def resolve_download_url(
             if override
             else pkg.get("format", "zip")
         )
-        download_url = _expand_template(url_template, version, os_name, arch, fmt)
+        replacements: dict = {
+            **pkg.get("replacements", {}),
+            **(override.get("replacements", {}) if override else {}),
+        }
+        resolved_os = replacements.get(os_name, os_name)
+        resolved_arch = replacements.get(arch, arch)
+        download_url = _expand_template(
+            url_template, version, resolved_os, resolved_arch, fmt
+        )
         filename = download_url.split("/")[-1]
         return AquaAsset(
             url=download_url,
@@ -160,21 +165,30 @@ def resolve_download_url(
             description=description,
         )
 
-    # ── type: github_release (default) ─────────────────────────────────────
+    # ── type: github_release ───────────────────────────────────────────────
     if override:
         asset_template = override.get("asset", pkg.get("asset", ""))
         fmt = override.get("format", pkg.get("format", "tar.gz"))
+        replacements: dict = {
+            **pkg.get("replacements", {}),
+            **override.get("replacements", {}),
+        }
         for os_override in override.get("overrides", []):
             if os_override.get("goos") == os_name:
                 fmt = os_override.get("format", fmt)
     else:
         asset_template = pkg.get("asset", "")
         fmt = pkg.get("format", "tar.gz")
+        replacements = pkg.get("replacements", {})
 
     if not asset_template:
         return None
 
-    filename = _expand_template(asset_template, version, os_name, arch, fmt)
+    resolved_os = replacements.get(os_name, os_name)
+    resolved_arch = replacements.get(arch, arch)
+    filename = _expand_template(
+        asset_template, version, resolved_os, resolved_arch, fmt
+    )
     download_url = (
         f"https://github.com/{owner}/{repo}/releases/download/{version}/{filename}"
     )

--- a/InstallRelease/providers/mise/schemas.py
+++ b/InstallRelease/providers/mise/schemas.py
@@ -24,3 +24,4 @@ class MiseToolInfo:
     repo: str
     aqua_path: str
     description: str = ""
+    version_source: str = "github_release"

--- a/README.md
+++ b/README.md
@@ -18,9 +18,48 @@ CLI to install any CLI
 
 
 
-**Install Release** is a CLI tool by name `ir` to install any single-binary executable package for your device(Linux/MacOS/WSL) directly from their GitHub or GitLab releases and keep them updated. Consider it as a CLI to install, update and remove any single binary tools from GitHub/GitLab releases.
+**Install Release** gives you the `ir` command to install and keep single-binary CLI tools updated on Linux, macOS, and WSL. It works with GitHub/GitLab releases and supports mise/aqua registry entries and Docker images.
 
-This can be any tool you want to install, which is pre-compiled for your device and present on GitHub or GitLab releases.
+This can be any tool you want to install, which is pre-compiled for your device and present on a supported provider.
+
+## Highlights
+
+#### [GitHub and GitLab releases](#install-tool-from-githubgitlab-releases-)
+
+`ir` is mainly built for installing CLI tools straight from GitHub or GitLab releases. Give it a repo URL, and it finds the right release asset for your system.
+
+```bash
+# Install from GitHub
+ir get https://github.com/denoland/deno
+
+# Install from GitLab
+ir get https://gitlab.com/gitlab-org/cli -n glab
+```
+
+#### [Package mode (`--pkg`)](#install-as-system-package-debrpmappimage-)
+
+Some tools ship better as `.deb`, `.rpm`, or `AppImage` packages. Use `--pkg` when you want `ir` to install that package instead of picking a standalone binary.
+
+```bash
+# Install any package from GitHub releases
+ir get https://github.com/redis/RedisInsight --pkg
+```
+
+#### Extra providers
+
+- [mise/aqua](#install-tool-via-mise-registry-): Install tools from registry metadata.
+
+```bash
+# Install from mise/aqua registry
+ir get mise@terraform
+```
+
+- [Docker](#install-docker-image-as-a-cli-tool-): Run container images like local CLIs.
+
+```bash
+# Install from Docker image (with custom name)
+ir get docker@mcr.microsoft.com/azure-cli -n az
+```
 
 <!-- <a href="https://asciinema.org/a/fzvnZV9t4l9irF5F?autoplay=1"><img src="https://asciinema.org/a/fzvnZV9t4l9irF5F.svg" alt="asciinema CLI demo" width="100%" /></a> -->
 
@@ -37,6 +76,7 @@ This can be any tool you want to install, which is pre-compiled for your device 
 ## Table of Contents 📚
 
 - [Table of Contents 📚](#table-of-contents-)
+- [Highlights](#highlights)
 - [Getting started ⚡](#getting-started)
   - [Installation](#installation)
   - [Manage your tools](#manage-your-tools)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -49,6 +49,7 @@ tasks:
           exit 1
         elif [ "{{.CLI_ARGS}}" = "py" ]; then
           docker inspect -f '{{`{{.State.Running}}`}}' ir-ubuntu 2>/dev/null | grep -q true || bash setup.sh ubuntu
+          docker exec ir-ubuntu /usr/local/bin/uv sync --dev
           uv run pytest -s .
         else
           bash setup.sh {{.CLI_ARGS}}

--- a/test/asset.yml
+++ b/test/asset.yml
@@ -29,6 +29,12 @@ repos:
     cmd: kubectl version --client
     grep: 'Client Version:'
 
+- name: aws-cli
+  cmd: ir get mise@aws-cli -n aws -y
+  validate:
+    cmd: aws --version
+    grep: "aws-cli"
+
 # - name: terraform
 #   cmd: ir get docker@hashicorp/terraform -y
 #   validate:


### PR DESCRIPTION

- Added a command to sync the development environment in Taskfile.yml when running tests in Docker.
- Improved the binary installation logic in install.py to disambiguate multiple binaries based on name.
- Updated the MiseInteractProvider to fetch version tags from GitHub based on the backend configuration.
- Enhanced the resolve_download_url function to handle package type and replacements more effectively.
- Added a new test case for validating the installation of aws-cli.