### PR TITLE
Fix `ir hold --unset` not working as intended

### DIFF
--- a/InstallRelease/cli.py
+++ b/InstallRelease/cli.py
@@ -240,12 +240,12 @@ def _hold(
     name: str = typer.Argument(
         None, help="Name of CLI tool for which updates will be kept on hold."
     ),
-    unset: bool = typer.Option(True, "--unset", help="Remove from hold."),
+    unset: bool = typer.Option(False, "--unset", help="Remove from hold."),
 ):
     """
     | Keep an installed CLI tool's updates on hold.
     """
-    hold(name, hold_update=unset)
+    hold(name, hold_update=not unset)
 
 
 @app.command(name="me")


### PR DESCRIPTION
# Summary
`--unset` flag to the `hold` subcommand was set to True by default, without a way to set it to False. Simultaneously, the `hold` subcommand would set the hold-flag of packages to this True value.

Now, `--unset` is set to False when not specified, and `hold` subcommand holds back packages without the `--unset` flag and unholds them with the flag.

# Testing
I tested locally that both `ir hold --unset` and `ir hold` function as expected:
- that `ir hold deno --unset` outputs `Update on hold for, deno to False`, `ir ls` then lists deno without `*HOLD_UPDATE*`, and `ir upgrade` then upgrades it;
- that `ir hold deno` outputs `Update on hold for, deno to True`, `ir ls` lists it as held, and `ir upgrade` ignores it.