### PR TITLE
Default to upgrade on empty input to the upgrade prompt

### DIFF
--- a/InstallRelease/cli_interact.py
+++ b/InstallRelease/cli_interact.py
@@ -184,7 +184,8 @@ def upgrade(
 
         if not skip_prompt:
             r = input()
-            if r.lower() != "y":
+            # default to Y on no input
+            if not (r.lower() == "y" or r.lower() == ""):
                 return
     else:
         pprint("[bold green]All tools are onto latest version")


### PR DESCRIPTION
The `(Y/n)` prompt suggests that the "default" action on an empty prompt would be "Y", i.e. to upgrade. This is now implemented.

Closes #305.