### PR TITLE
fix: enhance user prompts in GitInteractProvider for asset selection …

### DIFF
--- a/InstallRelease/providers/git/main.py
+++ b/InstallRelease/providers/git/main.py
@@ -95,46 +95,54 @@ def _show_pkg_hint(
                 return
 
 
-def _show_and_select_asset(release: Release, toolname: str) -> ReleaseAssets | None:
-    """Display all assets in a table and let the user pick one by ID."""
-
-    if not release.assets:
-        pprint("[red]No assets available for this release[/red]")
-        return None
-
-    assets_data = []
-    idx_map: dict[int, int] = {}
+def _selectable_assets(release: Release) -> dict[int, ReleaseAssets]:
+    """Return display IDs mapped to installable release assets."""
+    choices: dict[int, ReleaseAssets] = {}
     display_id = 1
-    for actual_idx, asset in enumerate(release.assets):
+    for asset in release.assets:
         if any(asset.name.lower().endswith(ext) for ext in PENALTY_EXTENSIONS):
             continue
+        choices[display_id] = asset
+        display_id += 1
+    return choices
+
+
+def _show_release_assets(release: Release, toolname: str) -> dict[int, ReleaseAssets]:
+    """Display release assets and return display IDs mapped to assets."""
+    choices = _selectable_assets(release)
+
+    if not choices:
+        pprint("[red]No assets available for this release[/red]")
+        return choices
+
+    assets_data = []
+    for display_id, asset in choices.items():
         assets_data.append(
             {
-                "ID": display_id,
+                "Asset ID": display_id,
                 "Filename": asset.name,
                 "Size (MB)": asset.size_mb(),
                 "Downloads": asset.download_count,
             }
         )
-        idx_map[display_id] = actual_idx
-        display_id += 1
 
     show_table(assets_data, title=f"📦 Available Assets for {toolname}")
-    pprint(
-        "\n[yellow]Enter your desired file ID to install (or 'n' to cancel): [/yellow]",
-        end="",
-    )
-    selection = input().strip()
+    return choices
 
-    if selection.lower() == "n":
-        return None
+
+def _select_asset_by_id(release: Release, selection: str) -> ReleaseAssets | None:
+    """Return the asset matching a display ID, or None for invalid input."""
+    choices = _selectable_assets(release)
     try:
         selected_id = int(selection)
-        if selected_id in idx_map:
-            return release.assets[idx_map[selected_id]]
-        pprint(f"[red]Invalid ID. Please select between 1 and {len(idx_map)}[/red]")
     except ValueError:
         pprint("[red]Invalid input. Please enter a number or 'n' to cancel[/red]")
+        return None
+
+    if selected_id in choices:
+        return choices[selected_id]
+
+    pprint(f"[red]Invalid ID. Please select between 1 and {len(choices)}[/red]")
     return None
 
 
@@ -244,7 +252,7 @@ class GitInteractProvider(InteractProvider):
         return cast(ReleaseAssets, result)
 
     def prompt(self, toolname: str, candidate: ReleaseAssets) -> str:
-        """Show repo info + selected asset details; return user's Y/n/? choice."""
+        """Show repo/assets info; return user's Y/n/asset ID choice."""
         release = self._selected_release
         if release is None or self.repo.info is None:
             return "y"
@@ -256,6 +264,7 @@ class GitInteractProvider(InteractProvider):
             f"\n[magenta]🔮 Language : {info.language or 'N/A'}"
             f"\n[yellow]🔥 Title    : {info.description}"
         )
+        _show_release_assets(release, toolname)
         show_table(
             data=[
                 {
@@ -269,7 +278,7 @@ class GitInteractProvider(InteractProvider):
             title=f"🚀 Install: {toolname}",
         )
         pprint(f"[color(6)]\nPath: {dest}")
-        pprint("[color(34)]Install selected tool? [Y/n/? to choose other]: ", end="")
+        pprint("[color(34)]Install selected tool? [Y/n/ Asset ID]: ", end="")
         return input().strip().lower() or "y"
 
     def install(
@@ -377,21 +386,21 @@ class GitInteractProvider(InteractProvider):
         if asset is None:
             return
 
-        # Step 3: confirm with user; '?' lets them pick a different asset manually
+        # Step 3: confirm with user or select a different asset by ID
         if prompt:
             decision = self.prompt(toolname, asset)
-            if decision == "?":
+            if decision == "y":
+                pprint("\n[magenta]Downloading...[/magenta]")
+            elif decision == "n":
+                return
+            else:
                 if self._selected_release is None:
                     return
-                selected = _show_and_select_asset(self._selected_release, toolname)
+                selected = _select_asset_by_id(self._selected_release, decision)
                 if selected is None:
                     return
                 asset = selected
                 custom_release_words = _extract_words_from_filename(asset.name)
-                pprint("\n[magenta]Downloading...[/magenta]")
-            elif decision != "y":
-                return
-            else:
                 pprint("\n[magenta]Downloading...[/magenta]")
 
         # Step 4: download, extract, and install binary/package

--- a/InstallRelease/providers/git/main.py
+++ b/InstallRelease/providers/git/main.py
@@ -38,16 +38,18 @@ from InstallRelease.utils import (
 
 os_package_type = detect_package_type_from_os_release()
 
-# Maps provider name -> (RepoInfo subclass, token accessor)
 _PROVIDER_CLASSES: dict[str, Any] = {
     "github": (GitHubInfo, lambda cfg: cfg.token),
     "gitlab": (GitlabInfo, lambda cfg: cfg.gitlab_token),
 }
 
 
+def _appimage_ok() -> bool:
+    return platform.system().lower() in PACKAGE_ALIASES.get("AppImage", [])
+
+
 def get_repo_info(repo_url: str, data: dict[str, Any] | None = None) -> RepoInfo:
     """Factory: return the appropriate RepoInfo subclass for *repo_url*."""
-    data = data or {}
     provider_name = Provider.resolve_provider(repo_url)
     try:
         if provider_name is None:
@@ -55,7 +57,7 @@ def get_repo_info(repo_url: str, data: dict[str, Any] | None = None) -> RepoInfo
                 "Unsupported repository URL. Only GitHub and GitLab URLs are supported."
             )
         cls, get_token = _PROVIDER_CLASSES[provider_name]
-        return cls(repo_url, data, get_token(config))
+        return cls(repo_url, data or {}, get_token(config))
     except (UnsupportedRepositoryError, ApiError) as e:
         logger.error(str(e))
         sys.exit(1)
@@ -68,80 +70,76 @@ def get_repo_info(repo_url: str, data: dict[str, Any] | None = None) -> RepoInfo
 
 
 def _extract_words_from_filename(filename: str) -> list[str]:
-    """Split a release asset filename into searchable keywords."""
     basename = filename.rsplit(".", 1)[0]
     return to_words(text=basename.replace(".", "-"), ignore_words=["v", "unknown"])
 
 
-def _resolve_release_words(custom: list[str] | None, cached: list[str] | None) -> tuple:
-    """Return (extra_words, disable_adjustments); priority: custom > cached > None."""
-    words = custom or cached
-    return words, bool(words)
+def _available_package_type(releases: list[Release]) -> str | None:
+    if not os_package_type:
+        return None
+    for release in releases:
+        types = {
+            t
+            for a in release.assets
+            if (t := detect_package_type_from_asset_name(a.name))
+        }
+        if os_package_type in types:
+            return os_package_type
+        if _appimage_ok() and "AppImage" in types:
+            return "AppImage"
+    return None
 
 
 def _show_pkg_hint(
     releases: list[Release], package_mode: bool, repo_url: str = ""
 ) -> None:
-    """Hint user about available OS package when not already in --pkg mode."""
     if package_mode or not os_package_type:
         return
-    for release in releases:
-        for asset in release.assets:
-            if detect_package_type_from_asset_name(asset.name) == os_package_type:
-                pprint(
-                    f"\n[bold orange1]>> 📦 A [green]{os_package_type}[/green] package is "
-                    f"available for this release. Use [green]ir get {repo_url} --pkg[/green] to install it.[/bold orange1]"
-                )
-                return
+    pkg = _available_package_type(releases)
+    if pkg:
+        pprint(
+            f"\n[bold orange1]>> 📦 A [green]{pkg}[/green] package is "
+            f"available for this release. Use [green]ir get {repo_url} --pkg[/green] to install it.[/bold orange1]"
+        )
 
 
 def _selectable_assets(release: Release) -> dict[int, ReleaseAssets]:
-    """Return display IDs mapped to installable release assets."""
-    choices: dict[int, ReleaseAssets] = {}
-    display_id = 1
-    for asset in release.assets:
-        if any(asset.name.lower().endswith(ext) for ext in PENALTY_EXTENSIONS):
-            continue
-        choices[display_id] = asset
-        display_id += 1
-    return choices
+    return {
+        i: asset
+        for i, asset in enumerate(release.assets, 1)
+        if not any(asset.name.lower().endswith(ext) for ext in PENALTY_EXTENSIONS)
+    }
 
 
 def _show_release_assets(release: Release, toolname: str) -> dict[int, ReleaseAssets]:
-    """Display release assets and return display IDs mapped to assets."""
     choices = _selectable_assets(release)
-
     if not choices:
         pprint("[red]No assets available for this release[/red]")
         return choices
-
-    assets_data = []
-    for display_id, asset in choices.items():
-        assets_data.append(
+    show_table(
+        [
             {
-                "Asset ID": display_id,
-                "Filename": asset.name,
-                "Size (MB)": asset.size_mb(),
-                "Downloads": asset.download_count,
+                "Asset ID": did,
+                "Filename": a.name,
+                "Size (MB)": a.size_mb(),
+                "Downloads": a.download_count,
             }
-        )
-
-    show_table(assets_data, title=f"📦 Available Assets for {toolname}")
+            for did, a in choices.items()
+        ],
+        title=f"📦 Available Assets for {toolname}",
+    )
     return choices
 
 
 def _select_asset_by_id(release: Release, selection: str) -> ReleaseAssets | None:
-    """Return the asset matching a display ID, or None for invalid input."""
     choices = _selectable_assets(release)
     try:
-        selected_id = int(selection)
+        sid = int(selection)
     except ValueError:
         pprint("[red]Invalid input. Please enter a number or 'n' to cancel[/red]")
         return None
-
-    if selected_id in choices:
-        return choices[selected_id]
-
+    if sid in choices:
+        return choices[sid]
     pprint(f"[red]Invalid ID. Please select between 1 and {len(choices)}[/red]")
     return None
 
@@ -150,11 +148,7 @@ def _select_asset_by_id(release: Release, selection: str) -> ReleaseAssets | Non
 
 
 class GitInteractProvider(InteractProvider):
-    """Interactive installer for GitHub/GitLab repositories.
-
-    Orchestrates: resolve (fetch releases) -> select (pick best asset)
-    -> prompt (confirm with user) -> install (extract + place binary) -> save_state.
-    """
+    """Interactive installer for GitHub/GitLab repositories."""
 
     def __init__(
         self,
@@ -169,71 +163,65 @@ class GitInteractProvider(InteractProvider):
         self._selected_release: Release | None = None
 
     def resolve(self, version: str = "", pre_release: bool = False) -> list[Release]:
-        """Fetch available releases from the git provider API."""
         pre_release = pre_release or pre_release_enabled()
         self._releases = self.repo.release(tag_name=version, pre_release=pre_release)
         return self._releases
 
-    def select(self, candidates: list[Release], **hints: Any) -> ReleaseAssets | None:
-        """Pick the best matching asset from releases using scoring heuristics.
+    def _filter_assets_for_pkg_mode(self, candidates: list[Release]) -> None:
+        """Narrow each release's assets to the target package type (or AppImage fallback)."""
+        for release in candidates:
+            native = [
+                a
+                for a in release.assets
+                if detect_package_type_from_asset_name(a.name) == self.package_type
+            ]
+            if native:
+                release.assets = native
+                continue
+            if _appimage_ok():
+                fallback = [
+                    a
+                    for a in release.assets
+                    if detect_package_type_from_asset_name(a.name) == "AppImage"
+                ]
+                if fallback:
+                    release.assets = fallback
+                    if self.package_type != "AppImage":
+                        logger.info(
+                            f"No {self.package_type} package found, falling back to AppImage"
+                        )
+                        self.package_type = "AppImage"
+                    continue
+            release.assets = []
 
-        In --pkg mode, filters assets to native package type (or AppImage fallback).
-        Then tries exact name match from cache/--file, else scores all assets.
-        """
+    def select(self, candidates: list[Release], **hints: Any) -> ReleaseAssets | None:
         extra_words: list[str] | None = hints.get("extra_words")
         disable_adjustments: bool = hints.get("disable_adjustments", False)
         known_names: set[str] = hints.get("known_names", set())
 
-        # Filter assets to matching package type when in --pkg mode
         if self.package_mode:
             if not self.package_type:
                 logger.error(
                     "Could not detect appropriate package type for your system"
                 )
                 return None
-
-            appimage_ok = platform.system().lower() in PACKAGE_ALIASES.get(
-                "AppImage", []
-            )
-            for release in candidates:
-                native = [
-                    a
-                    for a in release.assets
-                    if detect_package_type_from_asset_name(a.name) == self.package_type
-                ]
-                if native:
-                    release.assets = native
-                    continue
-
-                fallback = (
-                    [
-                        a
-                        for a in release.assets
-                        if detect_package_type_from_asset_name(a.name) == "AppImage"
-                    ]
-                    if appimage_ok
-                    else []
-                )
-                release.assets = fallback
-                if fallback and self.package_type != "AppImage":
-                    logger.info(
-                        f"No {self.package_type} package found, falling back to AppImage"
-                    )
-                    self.package_type = "AppImage"
+            self._filter_assets_for_pkg_mode(candidates)
 
         if not candidates:
             return None
 
         self._selected_release = candidates[0]
 
-        # Fast path: exact asset name match from --file flag or previous install
-        if known_names:
-            for a in candidates[0].assets:
-                if a.name in known_names:
-                    logger.debug(f"Exact asset match: '{a.name}'")
-                    return a
+        # Fast path: exact asset name match from --file or cache
+        for a in candidates[0].assets:
+            if a.name in known_names:
+                logger.debug(f"Exact asset match: '{a.name}'")
+                return a
 
-        # Score all assets by OS/arch compatibility and pick the best
+        # Score all assets by OS/arch compatibility
+        fallback_pkg = (
+            _available_package_type(candidates) if not self.package_mode else None
+        )
         result = get_release(
             releases=candidates,
             repo_url=self.repo.repo_url,
@@ -241,22 +229,36 @@ class GitInteractProvider(InteractProvider):
             disable_adjustments=disable_adjustments,
             package_type=self.package_type if self.package_mode else None,
         )
-        if result is False:
-            logger.error("No suitable release assets found")
-            repo_name = self.repo.repo_url.rstrip("/").rsplit("/", 1)[-1]
-            pprint(
-                f"[bold cyan]\nYou can retry installing via [mise] provider: "
-                f"\n[green]ir get mise@{repo_name}[/green][/]\n"
+
+        if result is not False:
+            return cast(ReleaseAssets, result)
+
+        # Auto-switch to --pkg mode if a native package is available
+        if fallback_pkg:
+            logger.info(
+                f"No standalone asset matched; switching to --pkg mode ({fallback_pkg})"
             )
-            return None
-        return cast(ReleaseAssets, result)
+            self.package_mode = True
+            self.package_type = fallback_pkg
+            return self.select(
+                candidates,
+                extra_words=extra_words,
+                disable_adjustments=disable_adjustments,
+                known_names=known_names,
+            )
+
+        logger.error("No suitable release assets found")
+        repo_name = self.repo.repo_url.rstrip("/").rsplit("/", 1)[-1]
+        pprint(
+            f"[bold cyan]\nYou can retry installing via [mise] provider: "
+            f"\n[green]ir get mise@{repo_name}[/green][/]\n"
+        )
+        return None
 
     def prompt(self, toolname: str, candidate: ReleaseAssets) -> str:
-        """Show repo/assets info; return user's Y/n/asset ID choice."""
         release = self._selected_release
         if release is None or self.repo.info is None:
             return "y"
-
         info = self.repo.info
         pprint(
             f"\n[green bold]📑 Repo     : {info.full_name}"
@@ -284,7 +286,6 @@ class GitInteractProvider(InteractProvider):
     def install(
         self, candidate: ReleaseAssets, toolname: str, temp_dir: str, local: bool
     ) -> bool:
-        """Download and install the selected asset as a package or binary."""
         release = self._selected_release
         if release is None:
             return False
@@ -292,7 +293,6 @@ class GitInteractProvider(InteractProvider):
         asset_pkg = detect_package_type_from_asset_name(candidate.name)
         effective_pkg = asset_pkg or (self.package_type if self.package_mode else None)
 
-        # Package install path: download and delegate to OS package manager
         if effective_pkg:
             if (
                 self.package_mode
@@ -312,18 +312,15 @@ class GitInteractProvider(InteractProvider):
             release.package_type = effective_pkg
             release.install_method = "package"
             release.package_name = pkg_installer.name
-        # Binary install path: extract archive and copy binary to dest
         else:
             extract_url(candidate.browser_download_url, temp_dir)
             release.assets = [candidate]
             mkdir(dest)
             if not install_bin(src=temp_dir, dest=dest, local=local, name=toolname):
                 return False
-
         return True
 
     def save_state(self, key: str, result: Release) -> None:
-        """Persist the installed release to the local cache."""
         save_state(key, result)
 
     def get(
@@ -335,48 +332,39 @@ class GitInteractProvider(InteractProvider):
         hold: bool = False,
         **kwargs: Any,
     ) -> None:
-        """Orchestrate the full install flow: resolve -> select -> prompt -> install -> save."""
         asset_file: str = kwargs.get("asset_file", "")
-
-        # Extract keywords from --file flag for asset matching
-        custom_release_words = (
+        custom_words = (
             _extract_words_from_filename(asset_file)
             if not is_none(asset_file)
             else None
         )
 
-        # Step 1: fetch releases from the provider API
+        # Step 1: fetch releases
         releases = self.resolve(version=version)
         if not releases:
             logger.error(f"No releases found: {self.repo.repo_url}")
             return
-
         if self.package_mode and not self.package_type:
             logger.error("Could not detect appropriate package type for your system")
             return
 
-        # Build asset-matching hints from --file flag, cached state, or defaults
+        # Build matching hints
         toolname = self.repo.repo_name.lower() if is_none(name) else name.lower()
         state_key = f"{self.repo.repo_url}#{toolname}"
+        cached = load_state(state_key)
+        cached_words = cached.custom_release_words if cached else None
+        extra_words = custom_words or cached_words
+        disable_adjustments = extra_words is not None
 
-        cached_release = load_state(state_key)
-        cached_custom_words = (
-            cached_release.custom_release_words if cached_release else None
-        )
-        extra_words, disable_adjustments = _resolve_release_words(
-            custom_release_words, cached_custom_words
-        )
-
-        # Exact name candidates (--file + cache)
         known_names: set[str] = set()
         if not is_none(asset_file):
             known_names.add(asset_file)
-        if cached_release and cached_release.assets:
-            known_names.add(cached_release.assets[0].name)
+        if cached and cached.assets:
+            known_names.add(cached.assets[0].name)
 
         _show_pkg_hint(releases, self.package_mode, self.repo.repo_url)
 
-        # Step 2: pick the best matching asset for this OS/arch
+        # Step 2: pick best asset
         asset = self.select(
             releases,
             extra_words=extra_words,
@@ -386,40 +374,34 @@ class GitInteractProvider(InteractProvider):
         if asset is None:
             return
 
-        # Step 3: confirm with user or select a different asset by ID
+        # Step 3: confirm with user
         if prompt:
             decision = self.prompt(toolname, asset)
-            if decision == "y":
-                pprint("\n[magenta]Downloading...[/magenta]")
-            elif decision == "n":
+            if decision == "n":
                 return
-            else:
+            if decision != "y":
                 if self._selected_release is None:
                     return
                 selected = _select_asset_by_id(self._selected_release, decision)
                 if selected is None:
                     return
                 asset = selected
-                custom_release_words = _extract_words_from_filename(asset.name)
-                pprint("\n[magenta]Downloading...[/magenta]")
+                custom_words = _extract_words_from_filename(asset.name)
+            pprint("\n[magenta]Downloading...[/magenta]")
 
-        # Step 4: download, extract, and install binary/package
-        at = TemporaryDirectory(prefix=f"dn_{self.repo.repo_name}_")
-        if not self.install(asset, toolname=toolname, temp_dir=at.name, local=local):
-            return
+        # Step 4: install
+        with TemporaryDirectory(prefix=f"dn_{self.repo.repo_name}_") as tmp:
+            if not self.install(asset, toolname=toolname, temp_dir=tmp, local=local):
+                return
 
-        # Step 5: persist release metadata + custom words to local cache
+        # Step 5: persist state
         release = self._selected_release
         if release is None:
             return
         release.hold_update = hold
-
-        resolved_words, _ = _resolve_release_words(
-            custom_release_words, cached_custom_words
-        )
+        resolved_words = custom_words or cached_words
         if resolved_words:
             release.custom_release_words = resolved_words
         if self.repo.info and self.repo.info.description:
             release.description = self.repo.info.description
-
         self.save_state(state_key, release)

--- a/InstallRelease/providers/git/main.py
+++ b/InstallRelease/providers/git/main.py
@@ -105,11 +105,12 @@ def _show_pkg_hint(
 
 
 def _selectable_assets(release: Release) -> dict[int, ReleaseAssets]:
-    return {
-        i: asset
-        for i, asset in enumerate(release.assets, 1)
+    selectable = [
+        asset
+        for asset in release.assets
         if not any(asset.name.lower().endswith(ext) for ext in PENALTY_EXTENSIONS)
-    }
+    ]
+    return dict(enumerate(selectable, 1))
 
 
 def _show_release_assets(release: Release, toolname: str) -> dict[int, ReleaseAssets]:

--- a/InstallRelease/providers/git/main.py
+++ b/InstallRelease/providers/git/main.py
@@ -27,6 +27,7 @@ from InstallRelease.providers.git.github import GitHubInfo
 from InstallRelease.providers.git.gitlab import GitlabInfo
 from InstallRelease.providers.git.schemas import Release, ReleaseAssets
 from InstallRelease.utils import (
+    DIM_TABLE_THEME,
     download,
     is_none,
     logger,
@@ -127,6 +128,7 @@ def _show_release_assets(release: Release, toolname: str) -> dict[int, ReleaseAs
             for did, a in choices.items()
         ],
         title=f"📦 Available Assets for {toolname}",
+        theme=DIM_TABLE_THEME,
     )
     return choices
 

--- a/InstallRelease/utils.py
+++ b/InstallRelease/utils.py
@@ -24,6 +24,15 @@ import zstandard as zstd
 from rich import print as pprint
 from rich.console import Console
 from rich.logging import RichHandler
+from rich.progress import (
+    BarColumn,
+    DownloadColumn,
+    Progress,
+    SpinnerColumn,
+    TextColumn,
+    TimeRemainingColumn,
+    TransferSpeedColumn,
+)
 from rich.table import Table
 from rich.text import Text
 
@@ -41,6 +50,8 @@ except ImportError:
 requests_session = requests.Session()
 
 console = Console()
+REQUEST_TIMEOUT = (10, 60)
+DOWNLOAD_CHUNK_SIZE = 1024 * 1024
 
 _colors = {
     "green": "#8CC265",
@@ -50,6 +61,13 @@ _colors = {
     "yellow": "#F0A45D bold",
     "red": "#E8678A",
     "purple": "#8782E9 bold",
+}
+
+_dim_colors = {
+    "title": "#B0B0B0",
+    "table": "#6F6F6F",
+    "border": "#565656",
+    "columns": ("#B0B0B0", "#9A9A9A", "#848484", "#9A9A9A", "#B0B0B0"),
 }
 
 
@@ -89,7 +107,7 @@ class PackageVersion:
             if self._latest_version is not None:
                 return self._latest_version
 
-            response = requests_session.get(self.url)
+            response = requests_session.get(self.url, timeout=REQUEST_TIMEOUT)
             logger.debug(
                 f"pipi response for package '{self.package_name}': " + str(response)
             )
@@ -134,6 +152,29 @@ class ShellOutputs:
     returncode: int
 
 
+@dataclass(frozen=True)
+class TableTheme:
+    title_style: str = _colors["light_green"]
+    table_style: str = _colors["purple"]
+    border_style: str = ""
+    column_styles: tuple[str, ...] = (
+        _colors["yellow"],
+        _colors["red"],
+        _colors["green"],
+        _colors["cyan"],
+        _colors["blue"],
+    )
+
+
+DIM_TABLE_THEME = TableTheme(
+    title_style=_dim_colors["title"],
+    table_style=_dim_colors["table"],
+    border_style=_dim_colors["border"],
+    column_styles=_dim_colors["columns"],
+)
+DEFAULT_TABLE_THEME = TableTheme()
+
+
 def sh(command: str, interactive: bool = False) -> ShellOutputs:
     """Run a shell command and return its output."""
     try:
@@ -172,19 +213,37 @@ def mkdir(path: str):
 def download(url: str, at: str):
     """Download a file"""
 
-    file = requests_session.get(url, stream=True)
-    if not os.path.exists(at):
-        os.makedirs(at)
-
     file_name: str = url.split("/")[-1]
-    if file.status_code == 200:
-        with open(f"{at}/{file_name}", "wb") as fw:
-            fw.write(file.content)
-        logger.info(f"""Downloaded: \'{file_name}\' at {at}""")
-        return f"{at}/{file_name}"
-    else:
-        logger.info(f"url: {url}, status_code: {file.status_code}")
-        exit()
+    if not os.path.exists(at):
+        os.makedirs(at, exist_ok=True)
+
+    with requests_session.get(url, stream=True, timeout=REQUEST_TIMEOUT) as file:
+        file.raise_for_status()
+        output_path = f"{at}/{file_name}"
+        total_bytes = int(file.headers.get("content-length") or 0)
+        progress_columns = [
+            SpinnerColumn(),
+            TextColumn("{task.description}"),
+            BarColumn(),
+            DownloadColumn(),
+            TransferSpeedColumn(),
+            TimeRemainingColumn(),
+        ]
+
+        with open(output_path, "wb") as fw, Progress(
+            *progress_columns,
+            console=console,
+            transient=True,
+        ) as progress:
+            task_id = progress.add_task(f"Downloading {file_name}", total=total_bytes or None)
+            for chunk in file.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE):
+                if not chunk:
+                    continue
+                fw.write(chunk)
+                progress.update(task_id, advance=len(chunk))
+
+    logger.info(f"""Downloaded: \'{file_name}\' at {at}""")
+    return f"{output_path}"
 
 
 def extract(path: str, at: str):
@@ -283,10 +342,12 @@ def show_table(
     title: str = "",
     border_style="",
     no_wrap: bool = True,
+    theme: TableTheme | None = None,
 ):
     """Render a rich table from a list of dicts."""
 
     ignore_keys = ignore_keys or []
+    theme = theme or DEFAULT_TABLE_THEME
 
     def dict_list_tbl(items: list[dict], ignored_keys: list[str]):
         keys = []
@@ -302,23 +363,19 @@ def show_table(
 
         return keys, data
 
-    text = Text(title, style=_colors["light_green"])
+    text = Text(title, style=theme.title_style)
 
     print()
 
-    table = Table(title=text, style=_colors["purple"], border_style=border_style)
+    table = Table(
+        title=text,
+        style=theme.table_style,
+        border_style=border_style or theme.border_style,
+    )
     columns, rows = dict_list_tbl(data, ignore_keys)
 
-    colors = {
-        0: _colors["yellow"],
-        1: _colors["red"],
-        2: _colors["green"],
-        3: _colors["cyan"],
-        4: _colors["blue"],
-    }
-
     for count, col in enumerate(columns):
-        color = colors[count % len(colors)]
+        color = theme.column_styles[count % len(theme.column_styles)]
         table.add_column(col, justify="left", style=color, no_wrap=no_wrap)
     for row in rows:
         table.add_row(*row)

--- a/README.md
+++ b/README.md
@@ -254,13 +254,20 @@ ir --install-completion zsh
 ✨ Language : Go
 🔥 Title    : Faster way to switch between clusters and namespaces in kubectl
 
+                    📦 Available Assets for kubectx
+┏━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┓
+┃ Asset ID ┃ Filename                           ┃ Size (MB) ┃ Downloads ┃
+┡━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━┩
+│ 1        │ kubectx_v0.9.4_linux_x86_64.tar.gz │ 1.0       │ 43811     │
+└──────────┴────────────────────────────────────┴───────────┴───────────┘
+
                               🚀 Install: kubectx
 ┏━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━┓
 ┃ Name    ┃ Selected Item                      ┃ Version ┃ Size Mb ┃ Downloads ┃
 ┡━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━┩
 │ kubectx │ kubectx_v0.9.4_linux_x86_64.tar.gz │ v0.9.4  │ 1.0     │ 43811     │
 └─────────┴────────────────────────────────────┴─────────┴─────────┴───────────┘
-Install selected tool? [Y/n/? to choose other]: y
+Install selected tool? [Y/n/ Asset ID]: y
  INFO     Downloaded: 'kubectx_v0.9.4_linux_x86_64.tar.gz' at /tmp/dn_kubectx_ph6i7dmk                                                               utils.py:159
  INFO     install /tmp/dn_kubectx_ph6i7dmk/kubectx /home/noobi/bin/kubectx                                                                  core.py:132
  INFO     Installed: kubectx
@@ -306,7 +313,7 @@ Some tools (like Terraform, Packer, etc.) don't publish platform-specific binari
 ┡━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
 │ terraform │ v1.12.0  │ terraform_1.12.0_linu... │ https://releases.hashicorp.c...  │
 └───────────┴──────────┴──────────────────────────┴──────────────────────────────────┘
-Install selected tool? [Y/n/? to choose other]: y
+Install selected tool? [Y/n]: y
 ```
 
 Tools installed via `mise@` are also tracked by `ir ls` and upgraded with `ir upgrade` just like GitHub/GitLab tools.
@@ -336,7 +343,7 @@ Tools installed via `mise@` are also tracked by `ir ls` and upgraded with `ir up
 ┡━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━┩
 │ terraform │ hashicorp/terraform   │ latest │
 └───────────┴───────────────────────┴────────┘
-Install selected tool? [Y/n/? to choose other]: y
+Install selected tool? [Y/n]: y
 ```
 
 - **Latest tags** (`latest`) are checked for updates via digest comparison during `ir upgrade` — only re-pulled when the remote image has changed.
@@ -349,7 +356,7 @@ In rare cases where install-release does not automatically find the correct rele
 
 ##### Method 1: Interactive Selection (Recommended)
 
-During the installation prompt, type `?` to view all available release assets and select the one you want:
+During the installation prompt, review the available release assets and type the asset ID you want to install:
 
 ```bash
 ❯ ir get https://github.com/ekzhang/bore
@@ -359,6 +366,17 @@ During the installation prompt, type `?` to view all available release assets an
 ✨ Language : Rust
 🔥 Title    : A simple CLI tool for making tunnels to localhost
 
+                    📦 Available Assets for bore
+┏━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┓
+┃ Asset ID ┃ Filename                                        ┃ Size (MB) ┃ Downloads ┃
+┡━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━┩
+│ 1        │ bore-v0.4.0-x86_64-unknown-linux-musl.tar.gz    │ 1.2       │ 1523      │
+│ 2        │ bore-v0.4.0-x86_64-unknown-linux-gnu.rpm        │ 1.3       │ 845       │
+│ 3        │ bore-v0.4.0-aarch64-unknown-linux-musl.deb      │ 1.1       │ 234       │
+│ 4        │ bore-v0.4.0-x86_64-apple-darwin.dmg             │ 1.2       │ 456       │
+│ 5        │ bore-v0.4.0-x86_64-apple-darwin.tar.gz          │ 1.2       │ 1523      │
+└──────────┴─────────────────────────────────────────────────┴───────────┴───────────┘
+
                               🚀 Install: bore
 ┏━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━┓
 ┃ Name ┃ Selected Item                            ┃ Version ┃ Size Mb ┃ Downloads ┃
@@ -367,20 +385,7 @@ During the installation prompt, type `?` to view all available release assets an
 └──────┴──────────────────────────────────────────┴─────────┴─────────┴───────────┘
 
 Path: /home/noobi/bin
-Install selected tool? [Y/n/? to choose other]: ?
-
-                    📦 Available Assets for bore
-┏━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┓
-┃ ID ┃ Filename                                        ┃ Size (MB) ┃ Downloads ┃
-┡━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━┩
-│ 1  │ bore-v0.4.0-x86_64-unknown-linux-musl.tar.gz    │ 1.2       │ 1523      │
-│ 2  │ bore-v0.4.0-x86_64-unknown-linux-gnu.rpm        │ 1.3       │ 845       │
-│ 3  │ bore-v0.4.0-aarch64-unknown-linux-musl.deb      │ 1.1       │ 234       │
-│ 4  │ bore-v0.4.0-x86_64-apple-darwin.dmg             │ 1.2       │ 456       │
-│ 5  │ bore-v0.4.0-x86_64-apple-darwin.tar.gz          │ 1.2       │ 1523      │
-└────┴─────────────────────────────────────────────────┴───────────┴───────────┘
-
-Enter your desired file ID to install (or 'n' to cancel): 3
+Install selected tool? [Y/n/ Asset ID]: 3
 ```
 
 The tool will automatically parse the selected filename into keywords and store them for future upgrades.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,23 +3,21 @@ name = "install-release"
 version = "0.7.7"
 readme = "README.md"
 description = "Simple package manager to easily install, update and manage any tool directly from github or gitlab releases"
-authors = [
-  { name = "Rishang", email = "rishangbhavsarcs@gmail.com" }
-]
+authors = [{ name = "Rishang", email = "rishangbhavsarcs@gmail.com" }]
 
 classifiers = [
-    "Intended Audience :: Information Technology",
-    "Intended Audience :: System Administrators",
-    "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python",
-    "Topic :: Software Development :: Libraries :: Python Modules",
-    "Topic :: Software Development :: Libraries",
-    "Topic :: Software Development :: Build Tools",
-    "Topic :: Software Development",
-    "Typing :: Typed",
-    "Development Status :: 4 - Beta",
-    "Intended Audience :: Developers",
+  "Intended Audience :: Information Technology",
+  "Intended Audience :: System Administrators",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+  "Topic :: Software Development :: Libraries",
+  "Topic :: Software Development :: Build Tools",
+  "Topic :: Software Development",
+  "Typing :: Typed",
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
 
 ]
 
@@ -64,17 +62,17 @@ include = ["InstallRelease*"]
 
 [tool.ruff.lint]
 select = [
-    "E",   # pycodestyle errors
-    "W",   # pycodestyle warnings
-    "F",   # pyflakes
-    "I",   # isort
-    "UP",  # pyupgrade
-    "B",   # flake8-bugbear
-    "C4",  # flake8-comprehensions
-    "RUF", # ruff-specific rules
+  "E",   # pycodestyle errors
+  "W",   # pycodestyle warnings
+  "F",   # pyflakes
+  "I",   # isort
+  "UP",  # pyupgrade
+  "B",   # flake8-bugbear
+  "C4",  # flake8-comprehensions
+  "RUF", # ruff-specific rules
 ]
 ignore = [
-    "E501", # line too long (handled by formatter)
+  "E501", # line too long (handled by formatter)
 ]
 
 [tool.ruff.format]
@@ -84,4 +82,3 @@ indent-style = "space"
 [project.scripts]
 install-release = "InstallRelease.cli:app"
 ir = "InstallRelease.cli:app"
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "install-release"
-version = "0.7.6"
+version = "0.7.7"
 readme = "README.md"
 description = "Simple package manager to easily install, update and manage any tool directly from github or gitlab releases"
 authors = [

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import io
+
+from rich.console import Console
+
+from InstallRelease import utils
+
+
+class _FakeResponse:
+    def __init__(self) -> None:
+        self.closed = False
+        self.iterated_chunk_size: int | None = None
+        self.headers = {"content-length": "6"}
+        self.status_code = 200
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def iter_content(self, chunk_size: int = 1024 * 1024):
+        self.iterated_chunk_size = chunk_size
+        yield b"ab"
+        yield b"cd"
+        yield b"ef"
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.closed = True
+        return False
+
+    @property
+    def content(self):
+        raise AssertionError("download() should stream chunks instead of reading content")
+
+
+def test_download_streams_to_disk_and_uses_timeout(tmp_path, monkeypatch):
+    fake_response = _FakeResponse()
+    captured: dict[str, object] = {}
+
+    def fake_get(url: str, **kwargs):
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return fake_response
+
+    monkeypatch.setattr(utils.requests_session, "get", fake_get)
+    monkeypatch.setattr(utils, "console", Console(file=io.StringIO(), force_terminal=False))
+
+    output = utils.download("https://example.com/helm-v4.2.0-linux-amd64.tar.gz", str(tmp_path))
+
+    assert output == f"{tmp_path}/helm-v4.2.0-linux-amd64.tar.gz"
+    assert (tmp_path / "helm-v4.2.0-linux-amd64.tar.gz").read_bytes() == b"abcdef"
+    assert captured["url"] == "https://example.com/helm-v4.2.0-linux-amd64.tar.gz"
+    assert captured["kwargs"]["stream"] is True
+    assert captured["kwargs"]["timeout"] == utils.REQUEST_TIMEOUT
+    assert fake_response.iterated_chunk_size == utils.DOWNLOAD_CHUNK_SIZE
+    assert fake_response.closed is True

--- a/uv.lock
+++ b/uv.lock
@@ -256,7 +256,7 @@ wheels = [
 
 [[package]]
 name = "install-release"
-version = "0.7.6"
+version = "0.7.7"
 source = { editable = "." }
 dependencies = [
     { name = "python-magic" },


### PR DESCRIPTION
drop of `?` arg in the prompt of asset selection, now assets will directly be printed in the `ir get` command for github/gitlab for making easy to view other assets in case incorrect asset file is selected for installation